### PR TITLE
Fix stack propagation bug in sections

### DIFF
--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -12,13 +12,13 @@
          variables_ct/1, sections_ct1/1, sections_ct2/1, sections_ct3/1, sections_ct4/1,
          lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
          indent_partials_ct/1, not_found_partials_ct1/1, not_found_partials_ct2/1, not_found_partials_ct3/1,
-         context_stack_ct/1, context_stack_ct2/1, partial_custom_reader_ct/1,
+         context_stack_ct/1, context_stack_ct2/1, nested_context_ct/1, partial_custom_reader_ct/1,
          unicode_render_ct/1
         ]).
 -define(ALL_TEST, [variables_ct, sections_ct1, sections_ct2, sections_ct3, sections_ct4,
                    lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
                    indent_partials_ct, not_found_partials_ct1, not_found_partials_ct2, not_found_partials_ct3,
-                   context_stack_ct, context_stack_ct2, partial_custom_reader_ct, unicode_render_ct]).
+                   context_stack_ct, context_stack_ct2, nested_context_ct, partial_custom_reader_ct, unicode_render_ct]).
 
 -define(config2, proplists:get_value).
 -define(debug(X), begin io:format("~p", [X]), X end).
@@ -197,6 +197,19 @@ context_stack_ct2(Config) ->
             {"items", [[{"item", 1}], [{"item", 2}], [{"item", 3}]]},
             {"a", [{"b", ["A", "B", "C"]}]}
            ],
+    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
+
+nested_context_ct(Config) ->
+    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"nested_context.mustache">>])),
+    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"nested_context.result">>])),
+
+    Data = [
+        {"list", ["ELEM 1", "ELEM 2", "ELEM 3"]},
+        {"util", [
+            {"lower", fun(Text, Render) -> string:to_lower(binary_to_list(Render(Text))) end},
+            {"titlecase", fun(Text, Render) -> string:titlecase(binary_to_list(Render(Text))) end}
+        ]}
+    ],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
 
 partial_custom_reader_ct(Config) ->

--- a/ct/bbmustache_SUITE_data/nested_context.mustache
+++ b/ct/bbmustache_SUITE_data/nested_context.mustache
@@ -1,0 +1,7 @@
+{{# list }}
+{{# util.titlecase }}
+{{# util.lower }}
+{{ . }}
+{{/ util.lower }}
+{{/ util.titlecase }}
+{{/ list }}

--- a/ct/bbmustache_SUITE_data/nested_context.result
+++ b/ct/bbmustache_SUITE_data/nested_context.result
@@ -1,0 +1,3 @@
+Elem 1
+Elem 2
+Elem 3


### PR DESCRIPTION
Consider the following mustache template:

```
Template = <<"
{{# list }}
{{# util.titlecase }}
{{# util.to_lower }}
{{ . }}
{{/ util.to_lower }}
{{/ util.titlecase }}
{{/ list }}
">>.
```

With the following data:

```
Data = #{
     "list" => ["ELEM 1", "ELEM 2", "ELEM 3"],
     "util" => #{
            "to_lower" => fun(Text, Render) -> string:to_lower(binary_to_list(Render(Text))) end,
             "titlecase" => fun(Text, Render) -> string:titlecase(binary_to_list(Render(Text))) end
      }
}.
```

If we run:

```
bbmustache:render(Template, Data).
```

We expect the following output:

```
Elem 1
Elem 2
Elem 3
```

But instead, we see the following:

```
```


This is because the stack context is not properly propagated when bbmustache iterates through lists.

[Here](https://jsfiddle.net/bdw2g6cL/) is a JS fiddle that shows this working properly in mustache.js.