### PR TITLE
Implement list properties

### DIFF
--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -10,13 +10,13 @@
          init_per_group/2, end_per_group/2,
 
          variables_ct/1, sections_ct1/1, sections_ct2/1, sections_ct3/1, sections_ct4/1,
-         lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
+         lists_ct/1, lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
          indent_partials_ct/1, not_found_partials_ct1/1, not_found_partials_ct2/1, not_found_partials_ct3/1,
          context_stack_ct/1, context_stack_ct2/1, nested_context_ct/1, partial_custom_reader_ct/1,
          unicode_render_ct/1
         ]).
 -define(ALL_TEST, [variables_ct, sections_ct1, sections_ct2, sections_ct3, sections_ct4,
-                   lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
+                   lists_ct, lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
                    indent_partials_ct, not_found_partials_ct1, not_found_partials_ct2, not_found_partials_ct3,
                    context_stack_ct, context_stack_ct2, nested_context_ct, partial_custom_reader_ct, unicode_render_ct]).
 
@@ -113,6 +113,13 @@ sections_ct4(Config) ->
     {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"invarted.result">>])),
 
     Data = [{"repo", []}],
+    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
+
+lists_ct(Config) ->
+    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"list_attributes.mustache">>])),
+    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"list_attributes.result">>])),
+
+    Data = [{"list1", [1, 2, 3]}, {"list2", []}],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
 
 lambdas_ct(Config) ->

--- a/ct/bbmustache_SUITE_data/list_attributes.mustache
+++ b/ct/bbmustache_SUITE_data/list_attributes.mustache
@@ -1,0 +1,19 @@
+List 1 length: {{ list1.length }}
+List 1 empty: {{ list1.empty }}
+
+List 2 length: {{ list2.length }}
+List 2 empty: {{ list2.empty }}
+
+{{# list1.empty }}
+Should not show
+{{/ list1.empty }}
+{{^ list1.empty }}
+List 1 is not empty
+{{/ list1.empty }}
+
+{{# list2.empty }}
+List 2 is empty
+{{/ list2.empty }}
+{{^ list2.empty }}
+Should now show
+{{/ list2.empty }}

--- a/ct/bbmustache_SUITE_data/list_attributes.result
+++ b/ct/bbmustache_SUITE_data/list_attributes.result
@@ -1,0 +1,9 @@
+List 1 length: 3
+List 1 empty: false
+
+List 2 length: 0
+List 2 empty: true
+
+List 1 is not empty
+
+List 2 is empty


### PR DESCRIPTION
Getting the length of the list, and modifying a template based on its emptyness are common operations.

This diff allows us to access the length/emptyness of a list in bbmustache by doing the following:

```
{{ list.length }}
{{ list.empty }}
```

[Here](https://jsfiddle.net/0ux29dmg/) is a JS fiddle which shows this working in mustache.js.