### PR TITLE
Enable maps/unicode support

### DIFF
--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -226,7 +226,6 @@ partial_custom_reader_ct(Config) ->
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))([])),
                                           ?config2(options, Config, []) ++ [{partial_file_reader, fun(_, Key) -> Key end}])).
 
--ifdef(unicode_supported).
 unicode_render_ct(Config) ->
     Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"unicode.mustache">>])),
     {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"unicode.result">>])),
@@ -248,17 +247,6 @@ unicode_render_ct(Config) ->
             {"name", 'まだない'}
            ],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data3)), ?config2(options, Config, []))).
--else.
-unicode_render_ct(Config) ->
-    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"unicode.mustache">>])),
-    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"unicode.result">>])),
-
-    Data1 = [
-            {"whoami", "猫"},
-            {"name", "まだない"}
-           ],
-    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data1)), ?config2(options, Config, []))).
--endif.
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Internal Functions

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,6 @@
 %% vim: set filetype=erlang : -*- erlang -*-
 
 {erl_opts, [
-            {platform_define, "^[0-9]+", namespaced_types},
-            {platform_define, "^20", unicode_supported},
             warnings_as_errors,
             warn_export_all,
             warn_untyped_record

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -162,11 +162,7 @@
 %% The default is `string/0'.
 %% If you want to change this, you need to specify `key_type' in {@link compile_option/0}.
 
--ifdef(namespaced_types).
 -type recursive_data() :: #{data_key() => term()} | [{data_key(), term()}].
--else.
--type recursive_data() :: [{data_key(), term()}].
--endif.
 %% It is a part of {@link data/0} that can have child elements.
 
 -type endtag()    :: {endtag, {state(), [key()], LastTagSize :: non_neg_integer(), Rest :: binary(), Result :: [tag()]}}.
@@ -695,7 +691,6 @@ get_data_recursive_impl([Key | RestKey] = Keys, Data, #?MODULE{context_stack = S
 
 %% @doc find the value of the specified key from {@link recursive_data/0}
 -spec find_data(data_key(), recursive_data() | term()) -> {ok, Value :: term()} | error.
--ifdef(namespaced_types).
 find_data(Key, Map) when is_map(Map) ->
     maps:find(Key, Map);
 find_data(Key, AssocList) when is_list(AssocList) ->
@@ -705,26 +700,12 @@ find_data(Key, AssocList) when is_list(AssocList) ->
     end;
 find_data(_, _) ->
     error.
--else.
-find_data(Key, AssocList) ->
-    case proplists:lookup(Key, AssocList) of
-        none   -> error;
-        {_, V} -> {ok, V}
-    end;
-find_data(_, _) ->
-    error.
--endif.
 
 %% @doc When the value is {@link recursive_data/0}, it returns true. Otherwise it returns false.
 -spec is_recursive_data(recursive_data() | term()) -> boolean().
--ifdef(namespaced_types).
 is_recursive_data([Tuple | _]) when is_tuple(Tuple) -> true;
 is_recursive_data(V) when is_map(V)                 -> true;
 is_recursive_data(_)                                -> false.
--else.
-is_recursive_data([Tuple | _]) when is_tuple(Tuple) -> true;
-is_recursive_data(_)                                -> false.
--endif.
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Escriptize


### PR DESCRIPTION
The given regexes in erl_opts do not define the macros in OTP 25+, preventing the usage of maps and unicode support.